### PR TITLE
Instances are now addressed by nativeId and not by their id.

### DIFF
--- a/lib/ec2-autoscaling-groups.js
+++ b/lib/ec2-autoscaling-groups.js
@@ -61,13 +61,15 @@ module.exports = function fetchAutoScalingGroups(config, result, cb) {
         var nameTag = _.find(autoScalingGroup.Tags, function(tag) {return tag.Key === 'Name'; });
         var id = nameTag.Value;
         var defName = nameTag.Value.split('-')[0];
-        var instances = _.pluck(autoScalingGroup.Instances, 'InstanceId');
+        var instances = _.chain(autoScalingGroup.Instances).pluck('InstanceId').map(function(instance) {
+          var found = _.find(result.topology.containers, function(cont) {
+            return cont.nativeId === instance;
+          });
+
+          return found;
+        }).without(undefined).value();
 
         var group = _.chain(instances).map(function(instance) {
-          return _.find(result.topology.containers, function(cont) {
-            return cont.nativeId = instance;
-          });
-        }).map(function(instance) {
           return instance.specific.securityGroups;
         }).flatten().pluck('GroupName').find(function(group) {
           return result.topology.containers[group];
@@ -100,18 +102,14 @@ module.exports = function fetchAutoScalingGroups(config, result, cb) {
           containedBy: containedBy,
           containerDefinitionId: defName,
           type: 'aws-autoscaling',
-          contains: instances,
+          contains: _.pluck(instances, 'id'),
           specific: autoScalingGroup,
           nativeId: autoScalingGroup.AutoScalingGroupName
         };
 
-        instances.forEach(function (instance) {
-          var container = containers[instance.InstanceId];
-          if (container) {
-            // update only the instances that are managed by nscale
-            container.type = 'blank-container';
-            container.containedBy = id;
-          }
+        instances.forEach(function (container) {
+          container.type = 'blank-container';
+          container.containedBy = id;
         });
       });
 

--- a/lib/ec2-autoscaling-groups.js
+++ b/lib/ec2-autoscaling-groups.js
@@ -64,7 +64,9 @@ module.exports = function fetchAutoScalingGroups(config, result, cb) {
         var instances = _.pluck(autoScalingGroup.Instances, 'InstanceId');
 
         var group = _.chain(instances).map(function(instance) {
-          return result.topology.containers[instance];
+          return _.find(result.topology.containers, function(cont) {
+            return cont.nativeId = instance;
+          });
         }).map(function(instance) {
           return instance.specific.securityGroups;
         }).flatten().pluck('GroupName').find(function(group) {

--- a/lib/ec2-instances.js
+++ b/lib/ec2-instances.js
@@ -38,7 +38,15 @@ module.exports = function fetchInstances(config, result, cb) {
       reservation.Instances.forEach(function(instance) {
 
         var nameTag = _.find(instance.Tags, function(tag) { return tag.Key === 'Name'; });
-        var id = instance.InstanceId;
+        var isAutoscaling = !!_.find(instance.Tags, function(tag) { return tag.Key === 'aws:autoscaling:groupName'; });
+        var id;
+
+        if (nameTag && !isAutoscaling) {
+          id = nameTag.Value;
+        }
+        else {
+          id = instance.InstanceId;
+        }
 
         var nativeId = instance.InstanceId;
         var containers;
@@ -48,7 +56,7 @@ module.exports = function fetchInstances(config, result, cb) {
                           name: nativeId,
                           nativeId: nativeId,
                           contains: [],
-                          type: 'aws-ami',
+                          type: !isAutoscaling? 'aws-ami': 'blank-container',
                           specific: {imageId: instance.ImageId,
                                      instanceId: instance.InstanceId,
                                      publicIpAddress: instance.PublicIpAddress,

--- a/lib/ec2-instances.js
+++ b/lib/ec2-instances.js
@@ -38,14 +38,8 @@ module.exports = function fetchInstances(config, result, cb) {
       reservation.Instances.forEach(function(instance) {
 
         var nameTag = _.find(instance.Tags, function(tag) { return tag.Key === 'Name'; });
-        var id;
+        var id = instance.InstanceId;
 
-        if (nameTag) {
-          id = nameTag.Value;
-        }
-        else {
-          id = instance.InstanceId;
-        }
         var nativeId = instance.InstanceId;
         var containers;
 

--- a/lib/postProcessing.js
+++ b/lib/postProcessing.js
@@ -71,7 +71,9 @@ module.exports = function postProcessing (system) {
       var sysAwsAutoScalingChild = sysContainers[cont.id].contains[0];
       _.forEach(cont.contains, function (instanceId) {
 
-        var container = containers[instanceId];
+        var container = _.find(containers, function(cont) {
+          return cont.nativeId === instanceId;
+        });
 
         if (!container) {
           // we are on a race condition between nscale and AWS autoscaling


### PR DESCRIPTION
This is needed because the aws-autoscaling-container now adds a name, which was previously used to flag instances as 'aws-ami' containers.